### PR TITLE
Use official microsoft dotnet image

### DIFF
--- a/6/dotnetcore/Dockerfile
+++ b/6/dotnetcore/Dockerfile
@@ -1,6 +1,6 @@
 ARG detect_latest_release_version=6.0.0
 
-FROM microsoft/dotnet:3.0.101-sdk
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 
 MAINTAINER Forest Keepers
 


### PR DESCRIPTION
Uses `mcr.microsoft.com/dotnet/core/sdk:3.0.101`

It is MIT so no problem.