### PR TITLE
Modifying Dockerfile to include Maven

### DIFF
--- a/6/java/Dockerfile
+++ b/6/java/Dockerfile
@@ -13,10 +13,23 @@ FROM java:8
 MAINTAINER Forest Keepers
 
 ARG detect_latest_release_version
+ARG MAVEN_VERSION=3.6.3
+ENV PATH /opt/apache-maven/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV M2_HOME /opt/apache-maven
+ENV MAVEN_HOME /opt/apache-maven
 ENV DETECT_LATEST_RELEASE_VERSION $detect_latest_release_version
 ENV DETECT_VERSION_KEY $detect_latest_release_version
 
 ENV SRC_PATH /code
+
+RUN wget -nc -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz https://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+    && wget -nc -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 https://www.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 \
+    && sha512sum /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz | grep `cat /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512` \
+    && tar -xzvf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/ \
+    && chown -R root:root /opt/apache-maven-${MAVEN_VERSION} \
+    && chmod -R 0755 /opt/apache-maven-${MAVEN_VERSION} \
+    && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/apache-maven \
+    && rm -f /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz*
 
 RUN mkdir -p /airgap/packaged-inspectors/gradle/
 COPY --from=builder /airgap/packaged-inspectors/gradle/ /airgap/packaged-inspectors/gradle/

--- a/6/java/scripts/entrypoint.sh
+++ b/6/java/scripts/entrypoint.sh
@@ -22,7 +22,9 @@ if [[ "$https_proxy_settings" =~ $pattern ]]; then
         host=${BASH_REMATCH[5]}
         port=${BASH_REMATCH[7]}
         export GRADLE_OPTS="$GRADLE_OPTS -Dhttps.proxyHost=$host -Dhttps.proxyPort=$port"
+        export MAVEN_OPTS="$MAVEN_OPTS -Dhttps.proxyHost=$host -Dhttps.proxyPort=$port -X"
         echo "[entrypoint] Setting GRADLE_OPTS: $GRADLE_OPTS"
+        echo "[entrypoint] Setting MAVEN_OPTS: $MAVEN_OPTS"
 fi
 
 exec "$@"


### PR DESCRIPTION
As a requirement to do blackduck scans on our Maven projects in Azure DevOps, we need the mvn executable added to the java image. I have discussed with @loafoe and he suggested i do a fork of the project and make a PR.