### PR TITLE
Update version of detect to 6.2.1

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         dockerfile: 6/java
         image-name: blackduck
-        tags: latest 6 6.1 6.1.0
+        tags: latest 6 6.2 6.2.1
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -30,7 +30,7 @@ jobs:
       with:
         dockerfile: 6/node
         image-name: blackduck
-        tags: node 6-node 6.1-node 6.1.0-node
+        tags: node 6-node 6.2-node 6.2.1-node
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -47,7 +47,7 @@ jobs:
       with:
         dockerfile: 6/golang
         image-name: blackduck
-        tags: golang 6-golang 6.1-golang 6.1.0-golang
+        tags: golang 6-golang 6.2-golang 6.2.1-golang
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -64,7 +64,7 @@ jobs:
       with:
         dockerfile: 6/dotnetcore-2.2.110
         image-name: blackduck
-        tags: dotnetcore-2.2.110 6-dotnetcore-2.2 6.1-dotnetcore-2.2.110 6.1.0-dotnetcore-2.2.110
+        tags: dotnetcore-2.2.110 6-dotnetcore-2.2 6.2-dotnetcore-2.2.110 6.2.1-dotnetcore-2.2.110
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -81,7 +81,7 @@ jobs:
       with:
         dockerfile: 6/dotnetcore-3.0.101
         image-name: blackduck
-        tags: 6.1-dotnetcore-3.0 6.1.0-dotnetcore-3.0.101
+        tags: 6.2-dotnetcore-3.0 6.2.1-dotnetcore-3.0.101
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -98,7 +98,7 @@ jobs:
       with:
         dockerfile: 6/dotnetcore-3.1.102
         image-name: blackduck
-        tags: dotnetcore 6-dotnetcore 6-dotnetcore-3 6-dotnetcore-3.1 6.1-dotnetcore 6.1-dotnetcore-3.1 6.1.0-dotnetcore 6.1.0-dotnetcore-3.1.102
+        tags: dotnetcore 6-dotnetcore 6-dotnetcore-3 6-dotnetcore-3.1 6.2-dotnetcore 6.2-dotnetcore-3.1 6.2.1-dotnetcore 6.2.1-dotnetcore-3.1.102
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/6/dotnetcore-2.2.110/Dockerfile
+++ b/6/dotnetcore-2.2.110/Dockerfile
@@ -1,7 +1,7 @@
 # This docker image is for supporting .net core sdk 2.2.110.
 # It is the most latest version supported in VS2017.
 # It is not available as docker image, so it is downloaded and extracted
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 MAINTAINER Forest Keepers

--- a/6/dotnetcore-3.0.101/Dockerfile
+++ b/6/dotnetcore-3.0.101/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 

--- a/6/dotnetcore-3.1.102/Dockerfile
+++ b/6/dotnetcore-3.1.102/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.102
 

--- a/6/golang/Dockerfile
+++ b/6/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM golang:1.13.5-stretch
 

--- a/6/java/Dockerfile
+++ b/6/java/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM alpine:latest AS builder
 ARG detect_latest_release_version

--- a/6/node/Dockerfile
+++ b/6/node/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=6.1.0
+ARG detect_latest_release_version=6.2.1
 
 FROM philipssoftware/node:java
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The version numbers are related to the version of blackduck in the image appende
 ## [Unreleased]
 
 ### Changed
+- Bumped detect version to 6.2.1
 - Bumped version to 6.1.0
 - Bumped version to 6.0.0
 - Bumped version to 5.6.2

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This contains all the similar tags at the point of creation.
 
 ```
 $ docker run philipssoftware/blackduck:6 cat TAGS
-blackduck blackduck:6 blackduck:6.1 blackduck:6.1.0
+blackduck blackduck:6 blackduck:6.2 blackduck:6.2.1
 ```
 
 You can use this to pin down a version of the container from an existing development build for production. When using `blackduck:6` for development. This ensures that you've got all security updates in your build. If you want to pin the version of your image down for production, you can use this file inside of the container to look for the most specific tag, the last one.
@@ -75,22 +75,22 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### blackduck
-- `blackduck`, `blackduck:6`, `blackduck:6.1`, `blackduck:6.1.0` [6/java/Dockerfile](6/java/Dockerfile)
+- `blackduck`, `blackduck:6`, `blackduck:6.2`, `blackduck:6.2.1` [6/java/Dockerfile](6/java/Dockerfile)
 
 ### blackduck with node
-- `blackduck:node`, `blackduck:6-node`, `blackduck:6.1-node`, `blackduck:6.1.0-node` [6/node/Dockerfile](6/node/Dockerfile)
+- `blackduck:node`, `blackduck:6-node`, `blackduck:6.2-node`, `blackduck:6.2.1-node` [6/node/Dockerfile](6/node/Dockerfile)
 
 ### blackduck with golang
-- `blackduck:golang`, `blackduck:6-golang`, `blackduck:6.1-golang`, `blackduck:6.1.0-golang` [6/golang/Dockerfile](6/golang/Dockerfile)
+- `blackduck:golang`, `blackduck:6-golang`, `blackduck:6.2-golang`, `blackduck:6.2.1-golang` [6/golang/Dockerfile](6/golang/Dockerfile)
 
 ### blackduck with dotnetcore-2.2.110
-- `blackduck:dotnetcore-2.2.110`, `blackduck:6-dotnetcore-2.2`, `blackduck:6.1-dotnetcore-2.2.110`, `blackduck:6.1.0-dotnetcore-2.2.110` [6/dotnetcore-2.2.110/Dockerfile](6/dotnetcore-2.2.110/Dockerfile)
+- `blackduck:dotnetcore-2.2.110`, `blackduck:6-dotnetcore-2.2`, `blackduck:6.2-dotnetcore-2.2.110`, `blackduck:6.2.1-dotnetcore-2.2.110` [6/dotnetcore-2.2.110/Dockerfile](6/dotnetcore-2.2.110/Dockerfile)
 
 ### blackduck with dotnetcore-3.0.101
-- `blackduck:6.1-dotnetcore-3.0`, `blackduck:6.1.0-dotnetcore-3.0.101` [6/dotnetcore-3.0.101/Dockerfile](6/dotnetcore-3.0.101/Dockerfile)
+- `blackduck:6.2-dotnetcore-3.0`, `blackduck:6.2.1-dotnetcore-3.0.101` [6/dotnetcore-3.0.101/Dockerfile](6/dotnetcore-3.0.101/Dockerfile)
 
 ### blackduck with dotnetcore-3.1.102
-- `blackduck:dotnetcore`, `blackduck:6-dotnetcore`, `blackduck:6-dotnetcore-3`, `blackduck:6-dotnetcore-3.1`, `blackduck:6.1-dotnetcore`, `blackduck:6.1-dotnetcore-3.1`, `blackduck:6.1.0-dotnetcore`, `blackduck:6.1.0-dotnetcore-3.1.102` [6/dotnetcore-3.1.102/Dockerfile](6/dotnetcore-3.1.102/Dockerfile)
+- `blackduck:dotnetcore`, `blackduck:6-dotnetcore`, `blackduck:6-dotnetcore-3`, `blackduck:6-dotnetcore-3.1`, `blackduck:6.2-dotnetcore`, `blackduck:6.2-dotnetcore-3.1`, `blackduck:6.2.1-dotnetcore`, `blackduck:6.2.1-dotnetcore-3.1.102` [6/dotnetcore-3.1.102/Dockerfile](6/dotnetcore-3.1.102/Dockerfile)
 
 ## Why
 


### PR DESCRIPTION
A new version of the detect scanner is available. Version 6.2.1

See: https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/62423113/Synopsys+Detect