### PR TITLE
bugfix: golang 1.15 not available as stretch anymore

### DIFF
--- a/6/golang/Dockerfile
+++ b/6/golang/Dockerfile
@@ -1,6 +1,6 @@
 ARG detect_latest_release_version=6.4.0
 
-FROM golang:1.15-stretch
+FROM golang:1.15.0-buster
 
 MAINTAINER Forest Keepers
 


### PR DESCRIPTION
Golang 1.15 doesn't ship as a debian stretch image anymore. Only as buster which is the successor of stretch.