### PR TITLE
Update to scanner version 7.10

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         dockerfile: 7/java
         image-name: blackduck
-        tags: latest 7 7.9 7.9.0
+        tags: latest 7 7.10 7.10.0
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -30,7 +30,7 @@ jobs:
       with:
         dockerfile: 7/node
         image-name: blackduck
-        tags: node 7-node 7.9-node 7.9.0-node
+        tags: node 7-node 7.10-node 7.10.0-node
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -47,7 +47,7 @@ jobs:
       with:
         dockerfile: 7/python
         image-name: blackduck
-        tags: python 7-python 7.9-python 7.9.0-python
+        tags: python 7-python 7.10-python 7.10.0-python
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -64,7 +64,7 @@ jobs:
       with:
         dockerfile: 7/golang
         image-name: blackduck
-        tags: golang 7-golang 7.9-golang 7.9.0-golang
+        tags: golang 7-golang 7.10-golang 7.10.0-golang
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -81,7 +81,7 @@ jobs:
       with:
         dockerfile: 7/dotnetcore-2.2.110
         image-name: blackduck
-        tags: dotnetcore-2.2.110 7-dotnetcore-2.2 7.9-dotnetcore-2.2.110 7.9.0-dotnetcore-2.2.110
+        tags: dotnetcore-2.2.110 7-dotnetcore-2.2 7.10-dotnetcore-2.2.110 7.10.0-dotnetcore-2.2.110
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -98,7 +98,7 @@ jobs:
       with:
         dockerfile: 7/dotnetcore-3.0.101
         image-name: blackduck
-        tags: 7.9-dotnetcore-3.0 7.9.0-dotnetcore-3.0.101
+        tags: 7.10-dotnetcore-3.0 7.10.0-dotnetcore-3.0.101
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -115,7 +115,7 @@ jobs:
       with:
         dockerfile: 7/dotnetcore-3.1.102
         image-name: blackduck
-        tags: 7.9.0-dotnetcore-3.1.102
+        tags: 7.10.0-dotnetcore-3.1.102
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -132,7 +132,7 @@ jobs:
       with:
         dockerfile: 7/dotnetcore-3.1.302
         image-name: blackduck
-        tags: dotnetcore 7-dotnetcore 7-dotnetcore-3 7-dotnetcore-3.1 7.9-dotnetcore 7.9-dotnetcore-3.1 7.9.0-dotnetcore 7.9.0-dotnetcore-3.1.302
+        tags: dotnetcore 7-dotnetcore 7-dotnetcore-3 7-dotnetcore-3.1 7.10-dotnetcore 7.10-dotnetcore-3.1 7.10.0-dotnetcore 7.10.0-dotnetcore-3.1.302
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
@@ -149,7 +149,7 @@ jobs:
       with:
         dockerfile: 7/docker
         image-name: blackduck
-        tags: docker 7-docker 7.9-docker 7.9.0-docker
+        tags: docker 7-docker 7.10-docker 7.10.0-docker
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'

--- a/7/docker/Dockerfile
+++ b/7/docker/Dockerfile
@@ -1,5 +1,5 @@
 # This docker image is for supporting docker detect.
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM alpine:latest AS builder
 MAINTAINER Forest Keepers

--- a/7/dotnetcore-2.2.110/Dockerfile
+++ b/7/dotnetcore-2.2.110/Dockerfile
@@ -1,7 +1,7 @@
 # This docker image is for supporting .net core sdk 2.2.110.
 # It is the most latest version supported in VS2017.
 # It is not available as docker image, so it is downloaded and extracted
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 MAINTAINER Forest Keepers

--- a/7/dotnetcore-3.0.101/Dockerfile
+++ b/7/dotnetcore-3.0.101/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 

--- a/7/dotnetcore-3.1.102/Dockerfile
+++ b/7/dotnetcore-3.1.102/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.102
 

--- a/7/dotnetcore-3.1.302/Dockerfile
+++ b/7/dotnetcore-3.1.302/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.302
 

--- a/7/golang/Dockerfile
+++ b/7/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM golang:1.16.4-buster
 

--- a/7/java/Dockerfile
+++ b/7/java/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM alpine:latest AS builder
 ARG detect_latest_release_version

--- a/7/node/Dockerfile
+++ b/7/node/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM philipssoftware/node:14.17.0-buster-slim-java
 

--- a/7/python/Dockerfile
+++ b/7/python/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=7.9.0
+ARG detect_latest_release_version=7.10.0
 
 FROM philipssoftware/python:java-3.9
 

--- a/README.md
+++ b/README.md
@@ -103,31 +103,31 @@ You can use this to pin down a version of the container from an existing develop
 ## Simple Tags
 
 ### blackduck
-- `blackduck`, `blackduck:7`, `blackduck:7.9`, `blackduck:7.9.0` [7/java/Dockerfile](7/java/Dockerfile)
+- `blackduck`, `blackduck:7`, `blackduck:7.10`, `blackduck:7.10.0` [7/java/Dockerfile](7/java/Dockerfile)
 
 ### blackduck with node
-- `blackduck:node`, `blackduck:7-node`, `blackduck:7.9-node`, `blackduck:7.9.0-node` [7/node/Dockerfile](7/node/Dockerfile)
+- `blackduck:node`, `blackduck:7-node`, `blackduck:7.10-node`, `blackduck:7.10.0-node` [7/node/Dockerfile](7/node/Dockerfile)
 
 ### blackduck with python
-- `blackduck:python`, `blackduck:7-python`, `blackduck:7.9-python`, `blackduck:7.9.0-python` [7/python/Dockerfile](7/python/Dockerfile)
+- `blackduck:python`, `blackduck:7-python`, `blackduck:7.10-python`, `blackduck:7.10.0-python` [7/python/Dockerfile](7/python/Dockerfile)
 
 ### blackduck with golang
-- `blackduck:golang`, `blackduck:7-golang`, `blackduck:7.9-golang`, `blackduck:7.9.0-golang` [7/golang/Dockerfile](7/golang/Dockerfile)
+- `blackduck:golang`, `blackduck:7-golang`, `blackduck:7.10-golang`, `blackduck:7.10.0-golang` [7/golang/Dockerfile](7/golang/Dockerfile)
 
 ### blackduck with dotnetcore-2.2.110
-- `blackduck:dotnetcore-2.2.110`, `blackduck:7-dotnetcore-2.2`, `blackduck:7.9-dotnetcore-2.2.110`, `blackduck:7.9.0-dotnetcore-2.2.110` [7/dotnetcore-2.2.110/Dockerfile](7/dotnetcore-2.2.110/Dockerfile)
+- `blackduck:dotnetcore-2.2.110`, `blackduck:7-dotnetcore-2.2`, `blackduck:7.10-dotnetcore-2.2.110`, `blackduck:7.10.0-dotnetcore-2.2.110` [7/dotnetcore-2.2.110/Dockerfile](7/dotnetcore-2.2.110/Dockerfile)
 
 ### blackduck with dotnetcore-3.0.101
-- `blackduck:7.9-dotnetcore-3.0`, `blackduck:7.9.0-dotnetcore-3.0.101` [7/dotnetcore-3.0.101/Dockerfile](7/dotnetcore-3.0.101/Dockerfile)
+- `blackduck:7.10-dotnetcore-3.0`, `blackduck:7.10.0-dotnetcore-3.0.101` [7/dotnetcore-3.0.101/Dockerfile](7/dotnetcore-3.0.101/Dockerfile)
 
 ### blackduck with dotnetcore-3.1.102
-- `blackduck:7.9.0-dotnetcore-3.1.102` [7/dotnetcore-3.1.102/Dockerfile](7/dotnetcore-3.1.102/Dockerfile)
+- `blackduck:7.10.0-dotnetcore-3.1.102` [7/dotnetcore-3.1.102/Dockerfile](7/dotnetcore-3.1.102/Dockerfile)
 
 ### blackduck with dotnetcore-3.1.302
-- `blackduck:dotnetcore`, `blackduck:7-dotnetcore`, `blackduck:7-dotnetcore-3`, `blackduck:7-dotnetcore-3.1`, `blackduck:7.9-dotnetcore`, `blackduck:7.-dotnetcore-3.1`, `blackduck:7.9.0-dotnetcore`, `blackduck:7.9.0-dotnetcore-3.1.302` [7/dotnetcore-3.1.302/Dockerfile](7/dotnetcore-3.1.302/Dockerfile)
+- `blackduck:dotnetcore`, `blackduck:7-dotnetcore`, `blackduck:7-dotnetcore-3`, `blackduck:7-dotnetcore-3.1`, `blackduck:7.10-dotnetcore`, `blackduck:7.-dotnetcore-3.1`, `blackduck:7.10.0-dotnetcore`, `blackduck:7.10.0-dotnetcore-3.1.302` [7/dotnetcore-3.1.302/Dockerfile](7/dotnetcore-3.1.302/Dockerfile)
 
 ### blackduck with docker detector
-- `blackduck:docker`, `blackduck:7-docker`, `blackduck:7.9-docker`, `blackduck:7.9.0-docker` [7/docker/Dockerfile](7/docker/Dockerfile)
+- `blackduck:docker`, `blackduck:7-docker`, `blackduck:7.10-docker`, `blackduck:7.10.0-docker` [7/docker/Dockerfile](7/docker/Dockerfile)
 
 ## Why
 


### PR DESCRIPTION
Update to latest version of Synopsis Detect 7.10

https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=releasenotes.html&_LANG=enus
https://github.com/blackducksoftware/synopsys-detect/releases/tag/7.10.0

Warning deprecates option `detect.yarn.prod.only`
