### PR TITLE
Use new version of docker-ci-scripts

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: ${{ matrix.name }}
-        uses: philips-software/docker-ci-scripts@v4.4.0
+        uses: philips-software/docker-ci-scripts@v4.5.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
           image-name: blackduck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The version numbers are related to the version of blackduck in the image appende
 
 ### Changed
 
+- Update versoin of docker-ci-scripts
 - Bumped detect version to 7.14.0
 - Bumped detect version to 7.13.2
 - Bumped detect version to 7.12.0


### PR DESCRIPTION
Use new version of docker-ci-scripts.

Version [v4.5.0](https://github.com/philips-software/docker-ci-scripts/releases/tag/v4.5.0) has been released with new container arguments.

This PR will be still using the old arguments to test the backwards compatibility and the deprecation warnings. Another PR will use the new defined arguments.