### PR TITLE
Detect 8.4.0 has been released

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -69,28 +69,28 @@ jobs:
         include:
           - name: Build BlackDuck Docker Images with java
             dockerfile: 8/java
-            tags: 8 8.3 8.3.0
+            tags: 8 8.4 8.4.0
           - name: Build BlackDuck Docker Images with node
             dockerfile: 8/node
-            tags: 8-node 8.3-node 8.3.0-node
+            tags: 8-node 8.4-node 8.4.0-node
           - name: Build BlackDuck Docker Images with python
             dockerfile: 8/python
-            tags: 8-python 8.3-python 8.3.0-python
+            tags: 8-python 8.4-python 8.4.0-python
           - name: Build BlackDuck Docker Images with golang
             dockerfile: 8/golang
-            tags: 8-golang 8.3-golang 8.3.0-golang
+            tags: 8-golang 8.4-golang 8.4.0-golang
           - name: Build BlackDuck Docker Images with dotnet core 2.2.110
             dockerfile: 8/dotnetcore-2.2.110
-            tags: 8-dotnetcore-2.2 8.3-dotnetcore-2.2.110 8.3.0-dotnetcore-2.2.110
+            tags: 8-dotnetcore-2.2 8.4-dotnetcore-2.2.110 8.4.0-dotnetcore-2.2.110
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.0.101
-            tags: 8.3-dotnetcore-3.0 8.3.0-dotnetcore-3.0.101
+            tags: 8.4-dotnetcore-3.0 8.4.0-dotnetcore-3.0.101
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.1.102
-            tags: 8.3-dotnetcore-3.1.102 8.3.0-dotnetcore-3.1.102
+            tags: 8.4-dotnetcore-3.1.102 8.4.0-dotnetcore-3.1.102
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.1.302
-            tags: 8-dotnetcore 8-dotnetcore-3 8-dotnetcore-3.1 8.3-dotnetcore 8.3-dotnetcore-3.1 8.3.0-dotnetcore 8.3.0-dotnetcore-3.1.302
+            tags: 8-dotnetcore 8-dotnetcore-3 8-dotnetcore-3.1 8.4-dotnetcore 8.4-dotnetcore-3.1 8.4.0-dotnetcore 8.4.0-dotnetcore-3.1.302
     steps:
       - uses: actions/checkout@v3
       - name: ${{ matrix.name }}

--- a/8/dotnetcore-2.2.110/Dockerfile
+++ b/8/dotnetcore-2.2.110/Dockerfile
@@ -1,7 +1,7 @@
 # This docker image is for supporting .net core sdk 2.2.110.
 # It is the most latest version supported in VS2017.
 # It is not available as docker image, so it is downloaded and extracted
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 MAINTAINER Forest Keepers

--- a/8/dotnetcore-3.0.101/Dockerfile
+++ b/8/dotnetcore-3.0.101/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 

--- a/8/dotnetcore-3.1.102/Dockerfile
+++ b/8/dotnetcore-3.1.102/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.102
 

--- a/8/dotnetcore-3.1.302/Dockerfile
+++ b/8/dotnetcore-3.1.302/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.302
 

--- a/8/golang/Dockerfile
+++ b/8/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM golang:1.16.4-buster
 

--- a/8/java/Dockerfile
+++ b/8/java/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM alpine:latest AS builder
 ARG detect_latest_release_version

--- a/8/node/Dockerfile
+++ b/8/node/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM philipssoftware/node:14.17.0-buster-slim-java
 

--- a/8/python/Dockerfile
+++ b/8/python/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.3.0
+ARG detect_latest_release_version=8.4.0
 
 FROM philipssoftware/python:java-3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The version numbers are related to the version of blackduck in the image appende
 
 ### Changed
 
+- Bumped detect version to 8.4.0
 - Bumped detect version to 8.3.0
 - Bumped detect version to 8.2.0
 - Use new arguments for docker-ci-scripts


### PR DESCRIPTION
Detect 8.4.0 has been released. https://github.com/blackducksoftware/synopsys-detect/releases/tag/8.4.0