### PR TITLE
Update detect version 8.6.0

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -69,28 +69,28 @@ jobs:
         include:
           - name: Build BlackDuck Docker Images with java
             dockerfile: 8/java
-            tags: 8 8.5 8.5.0
+            tags: 8 8.6 8.6.0
           - name: Build BlackDuck Docker Images with node
             dockerfile: 8/node
-            tags: 8-node 8.5-node 8.5.0-node
+            tags: 8-node 8.6-node 8.6.0-node
           - name: Build BlackDuck Docker Images with python
             dockerfile: 8/python
-            tags: 8-python 8.5-python 8.5.0-python
+            tags: 8-python 8.6-python 8.6.0-python
           - name: Build BlackDuck Docker Images with golang
             dockerfile: 8/golang
-            tags: 8-golang 8.5-golang 8.5.0-golang
+            tags: 8-golang 8.6-golang 8.6.0-golang
           - name: Build BlackDuck Docker Images with dotnet core 2.2.110
             dockerfile: 8/dotnetcore-2.2.110
-            tags: 8-dotnetcore-2.2 8.5-dotnetcore-2.2.110 8.5.0-dotnetcore-2.2.110
+            tags: 8-dotnetcore-2.2 8.6-dotnetcore-2.2.110 8.6.0-dotnetcore-2.2.110
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.0.101
-            tags: 8.5-dotnetcore-3.0 8.5.0-dotnetcore-3.0.101
+            tags: 8.6-dotnetcore-3.0 8.6.0-dotnetcore-3.0.101
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.1.102
-            tags: 8.5-dotnetcore-3.1.102 8.5.0-dotnetcore-3.1.102
+            tags: 8.6-dotnetcore-3.1.102 8.6.0-dotnetcore-3.1.102
           - name: Build BlackDuck Docker Images with dotnet core
             dockerfile: 8/dotnetcore-3.1.302
-            tags: 8-dotnetcore 8-dotnetcore-3 8-dotnetcore-3.1 8.5-dotnetcore 8.5-dotnetcore-3.1 8.5.0-dotnetcore 8.5.0-dotnetcore-3.1.302
+            tags: 8-dotnetcore 8-dotnetcore-3 8-dotnetcore-3.1 8.6-dotnetcore 8.6-dotnetcore-3.1 8.6.0-dotnetcore 8.6.0-dotnetcore-3.1.302
     steps:
       - uses: actions/checkout@v3
       - name: ${{ matrix.name }}

--- a/8/dotnetcore-2.2.110/Dockerfile
+++ b/8/dotnetcore-2.2.110/Dockerfile
@@ -1,7 +1,7 @@
 # This docker image is for supporting .net core sdk 2.2.110.
 # It is the most latest version supported in VS2017.
 # It is not available as docker image, so it is downloaded and extracted
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 MAINTAINER Forest Keepers

--- a/8/dotnetcore-3.0.101/Dockerfile
+++ b/8/dotnetcore-3.0.101/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101
 

--- a/8/dotnetcore-3.1.102/Dockerfile
+++ b/8/dotnetcore-3.1.102/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.102
 

--- a/8/dotnetcore-3.1.302/Dockerfile
+++ b/8/dotnetcore-3.1.302/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.302
 

--- a/8/golang/Dockerfile
+++ b/8/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM golang:1.16.4-buster
 

--- a/8/java/Dockerfile
+++ b/8/java/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM alpine:latest AS builder
 ARG detect_latest_release_version

--- a/8/node/Dockerfile
+++ b/8/node/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM philipssoftware/node:14.17.0-buster-slim-java
 

--- a/8/python/Dockerfile
+++ b/8/python/Dockerfile
@@ -1,4 +1,4 @@
-ARG detect_latest_release_version=8.5.0
+ARG detect_latest_release_version=8.6.0
 
 FROM philipssoftware/python:java-3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The version numbers are related to the version of blackduck in the image appende
 
 ### Changed
 
-- Bumped detect version to 8.5.0 
+- Bumped detect version to 8.6.0
+- Bumped detect version to 8.5.0
 - Bumped version of Maven to 3.8.7
 - Bumped detect version to 8.4.0
 - Bumped detect version to 8.3.0


### PR DESCRIPTION
A new version of Blackduck Detect Scanner is available.

https://github.com/blackducksoftware/synopsys-detect/blob/master/documentation/src/main/markdown/releasenotes.md#version-860

